### PR TITLE
Try to reset the drive in case they are in error state

### DIFF
--- a/dynaarm_driver/include/dynaarm_driver/dynaarm_hardware_interface.hpp
+++ b/dynaarm_driver/include/dynaarm_driver/dynaarm_hardware_interface.hpp
@@ -72,6 +72,7 @@ namespace dynaarm_driver {
             hardware_interface::CallbackReturn on_deactivate(const rclcpp_lifecycle::State &previous_state);
             hardware_interface::CallbackReturn on_error(const rclcpp_lifecycle::State &previous_state);
 
+
             hardware_interface::return_type read(const rclcpp::Time &time, const rclcpp::Duration &period);
             hardware_interface::return_type write(const rclcpp::Time &time, const rclcpp::Duration &period);
 


### PR DESCRIPTION
This PR might reset the drives at startup in case they are in error state. 

How the error reset works:

1. The drive needs to receive `ANYDRIVE_CW_ID_CLEAR_ERRORS_TO_STANDBY` as control word
2. Afterwards we can bring it back to ControlOp  (which internally goes step by step through the state machine and sends the corresponding control words to the drive)

It might be that this won't work because the ethercat communication is not running in the background