### PR TITLE
clamp target position according to urdf limits

### DIFF
--- a/dynaarm_driver/dynaarm_hardware_interface_base/include/dynaarm_hardware_interface_base/dynaarm_hardware_interface_base.hpp
+++ b/dynaarm_driver/dynaarm_hardware_interface_base/include/dynaarm_hardware_interface_base/dynaarm_hardware_interface_base.hpp
@@ -34,9 +34,9 @@
 
 // ros2_control hardware_interface
 #include <rclcpp/rclcpp.hpp>
-#include "hardware_interface/hardware_info.hpp"
-#include "hardware_interface/system_interface.hpp"
-#include "hardware_interface/types/hardware_interface_return_values.hpp"
+#include <hardware_interface/hardware_info.hpp>
+#include <hardware_interface/system_interface.hpp>
+#include <hardware_interface/types/hardware_interface_return_values.hpp>
 
 // ROS
 #include <rclcpp/macros.hpp>
@@ -54,12 +54,12 @@ class DynaArmHardwareInterfaceBase : public hardware_interface::SystemInterface
 public:
   RCLCPP_SHARED_PTR_DEFINITIONS(DynaArmHardwareInterfaceBase)
 
-  virtual ~DynaArmHardwareInterfaceBase();
   DynaArmHardwareInterfaceBase() : logger_(rclcpp::get_logger("DynaArmHardwareInterfaceBase"))
   {
     // This is only here otherwise the compiler will complain about the logger var.
     // We initialize the logger in on_init properly
   }
+  virtual ~DynaArmHardwareInterfaceBase();
 
   hardware_interface::CallbackReturn on_init(const hardware_interface::HardwareInfo& system_info);
   virtual hardware_interface::CallbackReturn on_init_derived(const hardware_interface::HardwareInfo& system_info) = 0;


### PR DESCRIPTION
This PR simply clamps the output target - on the joint side - before the serial translation to the limits specified in the URDF.

Some notes we have to keep in mind:

1. If the arm is for some reason behind the limit this will result into a jump in that axis to the limit
2. We only limit the position so far. It would also be possible to limit the velocity and effort fields if desired