### PR TITLE
Add support for using the same ethercat master from multiple hardware interfaces (Multi arm support)

### DIFF
--- a/dynaarm_driver/dynaarm_driver/include/dynaarm_driver/dynaarm_hardware_interface.hpp
+++ b/dynaarm_driver/dynaarm_driver/include/dynaarm_driver/dynaarm_hardware_interface.hpp
@@ -49,7 +49,9 @@
 #include <dynaarm_hardware_interface_base/dynaarm_hardware_interface_base.hpp>
 
 // sdk
-#include "ethercat_sdk_master/EthercatMaster.hpp"
+// As ros2control does not support sharing resources between hardware interfaces we need to resort to using a singleton
+// for managing the EthercatMasters
+#include "ethercat_sdk_master/EthercatMasterSingleton.hpp"
 #include <rsl_drive_sdk/Drive.hpp>
 
 namespace dynaarm_driver
@@ -68,9 +70,10 @@ public:
 
   void read_motor_states() override;
   void write_motor_commands() override;
+  hardware_interface::CallbackReturn on_configure() override;
 
 private:
-  ecat_master::EthercatMaster::SharedPtr ecat_master_;
+  ecat_master::EthercatMasterSingleton::Handle ecat_master_handle_;
   std::vector<rsl_drive_sdk::DriveEthercatDevice::SharedPtr> drives_;
 
   std::atomic<bool> startupAbortFlag_{ false };

--- a/dynaarm_driver/dynaarm_driver/include/dynaarm_driver/dynaarm_hardware_interface.hpp
+++ b/dynaarm_driver/dynaarm_driver/include/dynaarm_driver/dynaarm_hardware_interface.hpp
@@ -77,10 +77,7 @@ private:
   ecat_master::EthercatMasterSingleton::Handle ecat_master_handle_;
   std::vector<rsl_drive_sdk::DriveEthercatDevice::SharedPtr> drives_;
 
-  std::atomic<bool> startupAbortFlag_{ false };
-  std::atomic<bool> abrtFlag_{ false };
-
-  std::unique_ptr<std::thread> ecat_worker_thread_{};
+  bool ready_{ false };
 };
 
 }  // namespace dynaarm_driver

--- a/dynaarm_driver/dynaarm_driver/include/dynaarm_driver/dynaarm_hardware_interface.hpp
+++ b/dynaarm_driver/dynaarm_driver/include/dynaarm_driver/dynaarm_hardware_interface.hpp
@@ -70,7 +70,8 @@ public:
 
   void read_motor_states() override;
   void write_motor_commands() override;
-  hardware_interface::CallbackReturn on_configure() override;
+  hardware_interface::CallbackReturn
+  on_configure([[maybe_unused]] const rclcpp_lifecycle::State& previous_state) override;
 
 private:
   ecat_master::EthercatMasterSingleton::Handle ecat_master_handle_;

--- a/dynaarm_driver/dynaarm_driver/src/dynaarm_hardware_interface.cpp
+++ b/dynaarm_driver/dynaarm_driver/src/dynaarm_hardware_interface.cpp
@@ -88,7 +88,8 @@ DynaArmHardwareInterface::on_init_derived(const hardware_interface::HardwareInfo
   return hardware_interface::CallbackReturn::SUCCESS;
 }
 
-hardware_interface::CallbackReturn DynaArmHardwareInterface::on_configure()
+hardware_interface::CallbackReturn
+DynaArmHardwareInterface::on_configure([[maybe_unused]] const rclcpp_lifecycle::State& previous_state)
 {
   // This is a bit of a work around but doesn't work otherwise
   // We separate the activation of the ethercat bus into separate stages

--- a/dynaarm_driver/dynaarm_driver/src/dynaarm_mock_hardware_interface.cpp
+++ b/dynaarm_driver/dynaarm_driver/src/dynaarm_mock_hardware_interface.cpp
@@ -32,23 +32,25 @@ DynaarmMockHardwareInterface::on_init_derived(const hardware_interface::Hardware
 {
   // Read initial positions from hardware parameters
   std::vector<double> initial_positions;
-  
+
   if (info_.hardware_parameters.find("initial_positions") != info_.hardware_parameters.end()) {
     std::string initial_positions_str = info_.hardware_parameters.at("initial_positions");
-    
+
     // Remove brackets
-    initial_positions_str.erase(std::remove(initial_positions_str.begin(), initial_positions_str.end(), '['), initial_positions_str.end());
-    initial_positions_str.erase(std::remove(initial_positions_str.begin(), initial_positions_str.end(), ']'), initial_positions_str.end());
-    
+    initial_positions_str.erase(std::remove(initial_positions_str.begin(), initial_positions_str.end(), '['),
+                                initial_positions_str.end());
+    initial_positions_str.erase(std::remove(initial_positions_str.begin(), initial_positions_str.end(), ']'),
+                                initial_positions_str.end());
+
     // Split by comma and convert to doubles
     std::stringstream ss(initial_positions_str);
     std::string item;
-    
+
     while (std::getline(ss, item, ',')) {
       // Trim whitespace
       item.erase(0, item.find_first_not_of(" \t"));
       item.erase(item.find_last_not_of(" \t") + 1);
-      
+
       try {
         double value = std::stod(item);
         initial_positions.push_back(value);
@@ -57,16 +59,16 @@ DynaarmMockHardwareInterface::on_init_derived(const hardware_interface::Hardware
         initial_positions.push_back(0.0);
       }
     }
-    
+
     RCLCPP_INFO_STREAM(logger_, "Loaded " << initial_positions.size() << " initial positions from parameters");
   }
-  
+
   // Apply initial positions to joint states, motor states, and motor commands
   for (std::size_t i = 0; i < info_.joints.size(); i++) {
     const auto joint_name = info_.joints[i].name;
-    
-    double initial_pos = (i < initial_positions.size()) ? initial_positions[i] : 0.0;        
-    motor_command_vector_[i].position = initial_pos;    
+
+    double initial_pos = (i < initial_positions.size()) ? initial_positions[i] : 0.0;
+    motor_command_vector_[i].position = initial_pos;
   }
 
   RCLCPP_INFO_STREAM(logger_, "Successfully initialized dynaarm hardware interface for DynaarmMockHardwareInterface");

--- a/dynaarm_driver/dynaarm_hardware_interface_base/include/dynaarm_hardware_interface_base/dynaarm_hardware_interface_base.hpp
+++ b/dynaarm_driver/dynaarm_hardware_interface_base/include/dynaarm_hardware_interface_base/dynaarm_hardware_interface_base.hpp
@@ -78,8 +78,9 @@ public:
   hardware_interface::return_type write(const rclcpp::Time& time, const rclcpp::Duration& period);
   virtual void write_motor_commands() = 0;
 
-  virtual CallbackReturn on_configure()
+  CallbackReturn on_configure([[maybe_unused]] const rclcpp_lifecycle::State& previous_state) override
   {
+    RCLCPP_INFO_STREAM(logger_, "Base on_configure");
     return CallbackReturn::SUCCESS;
   }
 

--- a/dynaarm_driver/dynaarm_hardware_interface_base/include/dynaarm_hardware_interface_base/dynaarm_hardware_interface_base.hpp
+++ b/dynaarm_driver/dynaarm_hardware_interface_base/include/dynaarm_hardware_interface_base/dynaarm_hardware_interface_base.hpp
@@ -78,6 +78,11 @@ public:
   hardware_interface::return_type write(const rclcpp::Time& time, const rclcpp::Duration& period);
   virtual void write_motor_commands() = 0;
 
+  virtual CallbackReturn on_configure()
+  {
+    return CallbackReturn::SUCCESS;
+  }
+
   hardware_interface::return_type prepare_command_mode_switch(const std::vector<std::string>& start_interfaces,
                                                               const std::vector<std::string>& stop_interfaces);
 


### PR DESCRIPTION
This is currently more something like a POC and hasn't been tested yet. 

I had to separate the setup into a 2 stage process:

1. on_init -> get the master (singleton handles the creation if necessary) -> attach all devices to the bus
2. on_configure -> mark handle obtained in step 1 as ready (aka the user of that aquireMaster request is ready)
-> If all handles are marked as ready the ethercat bus is activated. 

The reason this needs to be separated is that the soem_interface (not sure about SOEM itself) does not support attaching new devices while the bus is active. 

Needs: https://github.com/Duatic/ethercat_sdk_master/pull/1