### PR TITLE
Fix default drive config file path in case a tf-prefix was used

### DIFF
--- a/dynaarm_driver/dynaarm_driver/src/dynaarm_hardware_interface.cpp
+++ b/dynaarm_driver/dynaarm_driver/src/dynaarm_hardware_interface.cpp
@@ -55,7 +55,16 @@ DynaArmHardwareInterface::on_init_derived(const hardware_interface::HardwareInfo
       RCLCPP_WARN_STREAM(logger_, "No configuration found for joint: " << joint_name << " in: " << base_directory
                                                                        << " Loading drive parameters from default "
                                                                           "location");
-      device_file_path = info_.hardware_parameters.at("drive_parameter_folder_default") + "/" + joint_name + ".yaml";
+      // The default parameters do not want the joint prefix in the path!
+      auto joint_wo_prefix = joint_name;
+      const auto tf_prefix = system_info.hardware_parameters.at("tf_prefix");
+      // Check if the joint name starts with the tf_prefix
+      if (joint_name.find(tf_prefix) == 0) {
+        // Remove it from the string
+        joint_wo_prefix.erase(0, tf_prefix.size());
+      }
+      device_file_path =
+          info_.hardware_parameters.at("drive_parameter_folder_default") + "/" + joint_wo_prefix + ".yaml";
     }
     RCLCPP_INFO_STREAM(logger_, "Drive file path " << device_file_path);
 


### PR DESCRIPTION
As discussed for multiarm setup we need to set the tf_prefix. Unfortunately the tf_prefix is included in the joint name (what actually makes sense from a ros2control point of view). 

The drive parameter files on the other hand are just in a folder + named after the joint they configure.
So we just remove the tf_prefix from the path again.

Discussion: This is currently only in case we fallback to the default parameters. If the user used an override for the folder we still apply the old logic. 