### PR TITLE
Gravity compensation controller now uses the commanded acceleration

### DIFF
--- a/dynaarm_controllers/include/dynaarm_controllers/gravity_compensation_controller.hpp
+++ b/dynaarm_controllers/include/dynaarm_controllers/gravity_compensation_controller.hpp
@@ -73,7 +73,7 @@ private:
 
   std::vector<std::reference_wrapper<hardware_interface::LoanedStateInterface>> joint_position_state_interfaces_;
   std::vector<std::reference_wrapper<hardware_interface::LoanedStateInterface>> joint_velocity_state_interfaces_;
-
+  std::vector<std::reference_wrapper<hardware_interface::LoanedStateInterface>> joint_acceleration_state_interfaces_;
   std::atomic_bool active_{ false };
 };
 }  // namespace dynaarm_controllers

--- a/dynaarm_controllers/src/gravity_compensation_controller.cpp
+++ b/dynaarm_controllers/src/gravity_compensation_controller.cpp
@@ -206,8 +206,6 @@ controller_interface::return_type GravityCompensationController::update([[maybe_
     q[pinocchio_model_.joints[idx].idx_q()] = joint_position_state_interfaces_.at(i).get().get_value();
     v[pinocchio_model_.joints[idx].idx_v()] = joint_velocity_state_interfaces_.at(i).get().get_value();
     a[pinocchio_model_.joints[idx].idx_v()] = joint_acceleration_state_interfaces_.at(i).get().get_value();
-
-    std::cout << joint_acceleration_state_interfaces_.at(i).get().get_value() << std::endl;
   }
 
   forwardKinematics(pinocchio_model_, pinocchio_data_, q, v, a);

--- a/dynaarm_controllers/src/gravity_compensation_controller.cpp
+++ b/dynaarm_controllers/src/gravity_compensation_controller.cpp
@@ -61,6 +61,7 @@ controller_interface::InterfaceConfiguration GravityCompensationController::stat
   for (auto& joint : joints) {
     config.names.emplace_back(joint + "/" + hardware_interface::HW_IF_POSITION);
     config.names.emplace_back(joint + "/" + hardware_interface::HW_IF_VELOCITY);
+    config.names.emplace_back(joint + "/" + "acceleration_commanded");
   }
 
   return config;
@@ -153,6 +154,11 @@ GravityCompensationController::on_activate([[maybe_unused]] const rclcpp_lifecyc
     RCLCPP_WARN(get_node()->get_logger(), "Could not get ordered state interfaces - velocity");
     return controller_interface::CallbackReturn::FAILURE;
   }
+  if (!controller_interface::get_ordered_interfaces(state_interfaces_, params_.joints, "acceleration_commanded",
+                                                    joint_acceleration_state_interfaces_)) {
+    RCLCPP_WARN(get_node()->get_logger(), "Could not get ordered state interfaces - acceleration");
+    return controller_interface::CallbackReturn::FAILURE;
+  }
 
   if (!controller_interface::get_ordered_interfaces(
           command_interfaces_, params_.joints, hardware_interface::HW_IF_EFFORT, joint_effort_command_interfaces_)) {
@@ -187,7 +193,7 @@ controller_interface::return_type GravityCompensationController::update([[maybe_
   // Build full-size vectors for all robot joints (Pinocchio expects this)
   Eigen::VectorXd q = Eigen::VectorXd::Zero(pinocchio_model_.nq);
   Eigen::VectorXd v = Eigen::VectorXd::Zero(pinocchio_model_.nv);
-
+  Eigen::VectorXd a = Eigen::VectorXd::Zero(pinocchio_model_.nv);
   // Map: Pinocchio joint name -> index in q/v
   for (std::size_t i = 0; i < joint_count; i++) {
     const std::string& joint_name = params_.joints[i];
@@ -199,10 +205,13 @@ controller_interface::return_type GravityCompensationController::update([[maybe_
     // Pinocchio joint index starts at 1, q/v index is idx-1
     q[pinocchio_model_.joints[idx].idx_q()] = joint_position_state_interfaces_.at(i).get().get_value();
     v[pinocchio_model_.joints[idx].idx_v()] = joint_velocity_state_interfaces_.at(i).get().get_value();
+    a[pinocchio_model_.joints[idx].idx_v()] = joint_acceleration_state_interfaces_.at(i).get().get_value();
+
+    std::cout << joint_acceleration_state_interfaces_.at(i).get().get_value() << std::endl;
   }
 
-  forwardKinematics(pinocchio_model_, pinocchio_data_, q, v);
-  const auto tau = pinocchio::rnea(pinocchio_model_, pinocchio_data_, q, v, Eigen::VectorXd::Zero(pinocchio_model_.nv));
+  forwardKinematics(pinocchio_model_, pinocchio_data_, q, v, a);
+  const auto tau = pinocchio::rnea(pinocchio_model_, pinocchio_data_, q, v, a);
 
   // Write only the efforts for this arm's joints
   for (std::size_t i = 0; i < joint_count; i++) {

--- a/dynaarm_driver/dynaarm_driver/src/dynaarm_hardware_interface.cpp
+++ b/dynaarm_driver/dynaarm_driver/src/dynaarm_hardware_interface.cpp
@@ -194,6 +194,7 @@ void DynaArmHardwareInterface::read_motor_states()
 
     motor_state_vector_[i].position = state.getJointPosition();
     motor_state_vector_[i].velocity = state.getJointVelocity();
+    motor_state_vector_[i].acceleration = state.getJointAcceleration();
     motor_state_vector_[i].effort = state.getJointTorque();
 
     motor_state_vector_[i].position_commanded = reading.getCommanded().getJointPosition();

--- a/dynaarm_driver/dynaarm_driver/src/dynaarm_mock_hardware_interface.cpp
+++ b/dynaarm_driver/dynaarm_driver/src/dynaarm_mock_hardware_interface.cpp
@@ -53,6 +53,7 @@ void DynaarmMockHardwareInterface::read_motor_states()
   for (std::size_t i = 0; i < info_.joints.size(); i++) {
     motor_state_vector_[i].position = motor_command_vector_[i].position;
     motor_state_vector_[i].velocity = motor_command_vector_[i].velocity;
+    motor_state_vector_[i].acceleration = 0.0;
     motor_state_vector_[i].effort = motor_command_vector_[i].effort;
 
     motor_state_vector_[i].temperature = 0.0;

--- a/dynaarm_driver/dynaarm_hardware_interface_base/include/dynaarm_hardware_interface_base/types.hpp
+++ b/dynaarm_driver/dynaarm_hardware_interface_base/include/dynaarm_hardware_interface_base/types.hpp
@@ -36,6 +36,7 @@ struct JointState
   std::string name;
   double position = 0.0;
   double velocity = 0.0;
+  double acceleration = 0.0;
   double effort = 0.0;
 
   double position_last = NAN;
@@ -63,6 +64,7 @@ struct MotorState
   std::string name;
   double position = 0.0;
   double velocity = 0.0;
+  double acceleration = 0.0;
   double effort = 0.0;
 
   double bus_voltage = 0.0;

--- a/dynaarm_driver/dynaarm_hardware_interface_base/include/dynaarm_hardware_interface_base/types.hpp
+++ b/dynaarm_driver/dynaarm_hardware_interface_base/include/dynaarm_hardware_interface_base/types.hpp
@@ -37,10 +37,12 @@ struct JointState
   double position = 0.0;
   double velocity = 0.0;
   double effort = 0.0;
+
   double position_last = NAN;
 
   double position_commanded = 0.0;
   double velocity_commanded = 0.0;
+  double acceleration_commanded = 0.0;
   double effort_commanded = 0.0;
 };
 
@@ -49,6 +51,7 @@ struct JointCommand
   std::string name;
   double position = 0.0;
   double velocity = 0.0;
+  double acceleration = 0.0;
   double effort = 0.0;
   double p_gain = 0.0;
   double i_gain = 0.0;

--- a/dynaarm_driver/dynaarm_hardware_interface_base/src/dynaarm_hardware_interface_base.cpp
+++ b/dynaarm_driver/dynaarm_hardware_interface_base/src/dynaarm_hardware_interface_base.cpp
@@ -86,6 +86,8 @@ std::vector<hardware_interface::StateInterface> DynaArmHardwareInterfaceBase::ex
         hardware_interface::StateInterface(joint_state.name, "position_commanded", &joint_state.position_commanded));
     state_interfaces.emplace_back(
         hardware_interface::StateInterface(joint_state.name, "velocity_commanded", &joint_state.velocity_commanded));
+    state_interfaces.emplace_back(hardware_interface::StateInterface(joint_state.name, "acceleration_commanded",
+                                                                     &joint_state.acceleration_commanded));
     state_interfaces.emplace_back(
         hardware_interface::StateInterface(joint_state.name, "effort_commanded", &joint_state.effort_commanded));
   }
@@ -140,6 +142,8 @@ std::vector<hardware_interface::CommandInterface> DynaArmHardwareInterfaceBase::
         joint_command.name, hardware_interface::HW_IF_POSITION, &joint_command.position));
     command_interfaces.emplace_back(hardware_interface::CommandInterface(
         joint_command.name, hardware_interface::HW_IF_VELOCITY, &joint_command.velocity));
+    command_interfaces.emplace_back(hardware_interface::CommandInterface(
+        joint_command.name, hardware_interface::HW_IF_ACCELERATION, &joint_command.acceleration));
     command_interfaces.emplace_back(hardware_interface::CommandInterface(
         joint_command.name, hardware_interface::HW_IF_EFFORT, &joint_command.effort));
 
@@ -237,6 +241,9 @@ hardware_interface::return_type DynaArmHardwareInterfaceBase::read(const rclcpp:
     joint_state_vector_[i].effort = joint_effort[i];
     joint_state_vector_[i].position_commanded = joint_position_commanded[i];
     joint_state_vector_[i].velocity_commanded = joint_velocity_commanded[i];
+    // NOTE we only feedback the desired acceleration at the moment as it is solely used in the gravity compensation
+    // controller
+    joint_state_vector_[i].acceleration_commanded = joint_command_vector_[i].acceleration;
     joint_state_vector_[i].effort_commanded = joint_effort_commanded[i];
   }
 


### PR DESCRIPTION
I implemented this feature as requested by @2nisi. 

In order to provide the gravity compensation controller with the commanded acceleration fields I had to add the acceleration as a command in hardware interface and expose it again as a state interface.

In order to use this feature remember to tell the JTC to use the `acceleration` command in your controller.yaml

```
joint_trajectory_controller:
  ros__parameters:
    joints:
      - shoulder_rotation
      - shoulder_flexion
      - elbow_flexion
      - forearm_rotation
      - wrist_flexion
      - wrist_rotation
    command_interfaces:
      - position
      - velocity
      - acceleration  # THIS ONE
    state_interfaces:
      - position
      - velocity
    # See https://control.ros.org/jazzy/doc/ros2_controllers/joint_trajectory_controller/doc/parameters.html for a full list of all parameters
    allow_partial_joints_goal: false # trajectory needs to contains goals from all joints handled by the controller
    constraints:
      stopped_velocity_tolerance: 0.5
      goal_time: 0.05
      # Tolerances for each joint
      shoulder_rotation: { trajectory: 0.5, goal: 0.05 }
      shoulder_flexion: { trajectory: 0.5, goal: 0.05 }
      elbow_flexion: { trajectory: 0.5, goal: 0.05 }
      forearm_rotation: { trajectory: 0.5, goal: 0.05 }
      wrist_flexion: { trajectory: 0.5, goal: 0.05 }
      wrist_rotation: { trajectory: 0.5, goal: 0.05 }

```

EDIT in addtion this PR also adds the acceleration measurements of the drive to the state interfaces