### PR TITLE
Let the gravity compensation controller publish its commanded torques  to ~/state

### DIFF
--- a/dynaarm_controllers/include/dynaarm_controllers/gravity_compensation_controller.hpp
+++ b/dynaarm_controllers/include/dynaarm_controllers/gravity_compensation_controller.hpp
@@ -33,6 +33,10 @@
 #include <hardware_interface/loaned_command_interface.hpp>
 #include <hardware_interface/loaned_state_interface.hpp>
 #include <trajectory_msgs/msg/joint_trajectory.hpp>
+#include <dynaarm_msgs/msg/gravity_compensation_controller_status.hpp>
+
+// ROS2
+#include <realtime_tools/realtime_publisher.hpp>
 
 // Pinocchio
 #include <pinocchio/algorithm/compute-all-terms.hpp>
@@ -75,5 +79,10 @@ private:
   std::vector<std::reference_wrapper<hardware_interface::LoanedStateInterface>> joint_velocity_state_interfaces_;
 
   std::atomic_bool active_{ false };
+
+  using StatusMsg = dynaarm_msgs::msg::GravityCompensationControllerStatus;
+  using StatusMsgPublisher = realtime_tools::RealtimePublisher<StatusMsg>;
+  rclcpp::Publisher<StatusMsg>::SharedPtr status_pub_;
+  std::unique_ptr<StatusMsgPublisher> status_pub_rt_;
 };
 }  // namespace dynaarm_controllers

--- a/dynaarm_controllers/src/gravity_compensation_controller.cpp
+++ b/dynaarm_controllers/src/gravity_compensation_controller.cpp
@@ -128,6 +128,10 @@ GravityCompensationController::on_configure([[maybe_unused]] const rclcpp_lifecy
     }
   }
 
+  // The status publisher
+  status_pub_ = get_node()->create_publisher<StatusMsg>("~/state", 10);  // TODO(firesurfer) what is the right qos ?
+  status_pub_rt_ = std::make_unique<StatusMsgPublisher>(status_pub_);
+
   return controller_interface::CallbackReturn::SUCCESS;
 }
 
@@ -204,6 +208,8 @@ controller_interface::return_type GravityCompensationController::update([[maybe_
   forwardKinematics(pinocchio_model_, pinocchio_data_, q, v);
   const auto tau = pinocchio::rnea(pinocchio_model_, pinocchio_data_, q, v, Eigen::VectorXd::Zero(pinocchio_model_.nv));
 
+  StatusMsg state_msg;
+  state_msg.timestamp = time;
   // Write only the efforts for this arm's joints
   for (std::size_t i = 0; i < joint_count; i++) {
     const std::string& joint_name = params_.joints[i];
@@ -211,10 +217,19 @@ controller_interface::return_type GravityCompensationController::update([[maybe_
     double effort = tau[pinocchio_model_.joints[idx].idx_v()];
     bool success = joint_effort_command_interfaces_.at(i).get().set_value(effort);
 
+    state_msg.joints.push_back(joint_name);
+    state_msg.commanded_torque.push_back(effort);
+
     if (!success) {
       RCLCPP_ERROR(get_node()->get_logger(), "Failed to set new effort value for joint interface at index %zu.", i);
       return controller_interface::return_type::ERROR;
     }
+  }
+  // and we try to have our realtime publisher publish the message
+  // if this doesn't succeed - well it will probably next time
+  if (params_.enable_state_topic && status_pub_rt_->trylock()) {
+    status_pub_rt_->msg_ = state_msg;
+    status_pub_rt_->unlockAndPublish();
   }
 
   return controller_interface::return_type::OK;

--- a/dynaarm_controllers/src/gravity_compensation_controller_parameters.yaml
+++ b/dynaarm_controllers/src/gravity_compensation_controller_parameters.yaml
@@ -9,3 +9,7 @@ gravity_compensation_controller:
     type: string
     default_value: "dynaarm"
     description: "name of the arm hardware interface"
+  enable_state_topic:
+    type: bool
+    default_value: true
+    description: "Publish a status message on the ~/state topic"

--- a/dynaarm_msgs/CMakeLists.txt
+++ b/dynaarm_msgs/CMakeLists.txt
@@ -14,6 +14,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/ArmState.msg"
   "msg/DriveState.msg"
   "msg/PIDGains.msg"
+  "msg/GravityCompensationControllerStatus.msg"
   DEPENDENCIES std_msgs
 )
 

--- a/dynaarm_msgs/msg/GravityCompensationControllerStatus.msg
+++ b/dynaarm_msgs/msg/GravityCompensationControllerStatus.msg
@@ -1,0 +1,8 @@
+# Timestamp
+builtin_interfaces/Time timestamp
+
+# List of all handled joint names
+string[] joints
+
+# Commanded torque
+float64[] commanded_torque


### PR DESCRIPTION
See description.

Publish to the state topic can be disabled via `enable_state_topic` parameter (which is true per default)